### PR TITLE
Missing `getCases()` method

### DIFF
--- a/src/scope.js
+++ b/src/scope.js
@@ -99,7 +99,7 @@ class Scope {
   }
   /**
    * Returns all available cases for this scope.
-   * @return {Array[ErrorCase]}
+   * @return {Array<ErrorCase>}
    */
   getCases() {
     return this._cases;


### PR DESCRIPTION
### What does this PR do?
[parserror.js](https://github.com/homer0/parserror/blob/master/src/parserror.js#L278) calls `scope.getCases()` but there is no such method in the Scope class; this PR adds it.